### PR TITLE
fix(settings): Expose run period and north on all settings

### DIFF
--- a/pollination/honeybee_energy/baseline.py
+++ b/pollination/honeybee_energy/baseline.py
@@ -12,18 +12,18 @@ class Geometry2004(Function):
     """
 
     model = Inputs.file(
-        description='Honeybee model in JSON format.', path='model.json',
+        description='Honeybee model in JSON format.', path='model.hbjson',
         extensions=['hbjson', 'json']
     )
 
     @command
     def geometry_2004(self):
-        return 'honeybee-energy baseline geometry-2004 model.json ' \
-            '--output-file new_model.json'
+        return 'honeybee-energy baseline geometry-2004 model.hbjson ' \
+            '--output-file new_model.hbjson'
 
     new_model = Outputs.file(
         description='Model JSON with its properties edited to conform to ASHRAE '
-        '90.1 appendix G.', path='new_model.json'
+        '90.1 appendix G.', path='new_model.hbjson'
     )
 
 
@@ -36,7 +36,7 @@ class Constructions2004(Function):
     """
 
     model = Inputs.file(
-        description='Honeybee model in JSON format.', path='model.json',
+        description='Honeybee model in JSON format.', path='model.hbjson',
         extensions=['hbjson', 'json']
     )
 
@@ -53,12 +53,12 @@ class Constructions2004(Function):
 
     @command
     def constructions_2004(self):
-        return 'honeybee-energy baseline constructions-2004 model.json ' \
-            '{{self.climate_zone}} --output-file new_model.json'
+        return 'honeybee-energy baseline constructions-2004 model.hbjson ' \
+            '{{self.climate_zone}} --output-file new_model.hbjson'
 
     new_model = Outputs.file(
         description='Model JSON with its properties edited to conform to ASHRAE '
-        '90.1 appendix G.', path='new_model.json'
+        '90.1 appendix G.', path='new_model.hbjson'
     )
 
 
@@ -73,18 +73,18 @@ class Lighting2004(Function):
     """
 
     model = Inputs.file(
-        description='Honeybee model in JSON format.', path='model.json',
+        description='Honeybee model in JSON format.', path='model.hbjson',
         extensions=['hbjson', 'json']
     )
 
     @command
     def lighting_2004(self):
-        return 'honeybee-energy baseline lighting-2004 model.json ' \
-            '--output-file new_model.json'
+        return 'honeybee-energy baseline lighting-2004 model.hbjson ' \
+            '--output-file new_model.hbjson'
 
     new_model = Outputs.file(
         description='Model JSON with its properties edited to conform to ASHRAE '
-        '90.1 appendix G.', path='new_model.json'
+        '90.1 appendix G.', path='new_model.hbjson'
     )
 
 
@@ -98,7 +98,7 @@ class Hvac2004(Function):
     """
 
     model = Inputs.file(
-        description='Honeybee model in JSON format.', path='model.json',
+        description='Honeybee model in JSON format.', path='model.hbjson',
         extensions=['hbjson', 'json']
     )
 
@@ -138,14 +138,14 @@ class Hvac2004(Function):
 
     @command
     def hvac_2004(self):
-        return 'honeybee-energy baseline hvac-2004 model.json {{self.climate_zone}} ' \
+        return 'honeybee-energy baseline hvac-2004 model.hbjson {{self.climate_zone}} ' \
             '--{{self.is_residential}} --{{self.energy_source}} ' \
             '--story-count {{self.story_count}} --floor-area {{self.floor_area}} ' \
-            '--output-file new_model.json'
+            '--output-file new_model.hbjson'
 
     new_model = Outputs.file(
         description='Model JSON with its properties edited to conform to ASHRAE '
-        '90.1 appendix G.', path='new_model.json'
+        '90.1 appendix G.', path='new_model.hbjson'
     )
 
 
@@ -158,16 +158,16 @@ class RemoveEcms(Function):
     """
 
     model = Inputs.file(
-        description='Honeybee model in JSON format.', path='model.json',
+        description='Honeybee model in JSON format.', path='model.hbjson',
         extensions=['hbjson', 'json']
     )
 
     @command
     def remove_ecms(self):
-        return 'honeybee-energy baseline remove-ecms model.json ' \
-            '--output-file new_model.json'
+        return 'honeybee-energy baseline remove-ecms model.hbjson ' \
+            '--output-file new_model.hbjson'
 
     new_model = Outputs.file(
         description='Model JSON with its properties edited to conform to ASHRAE '
-        '90.1 appendix G.', path='new_model.json'
+        '90.1 appendix G.', path='new_model.hbjson'
     )

--- a/pollination/honeybee_energy/settings.py
+++ b/pollination/honeybee_energy/settings.py
@@ -11,6 +11,18 @@ class SimParDefault(Function):
         'SimulationParameter', path='input.ddy', extensions=['ddy']
     )
 
+    run_period = Inputs.str(
+        description='An AnalysisPeriod string or an IDF RunPeriod string to set the '
+        'start and end dates of the simulation (eg. "6/21 to 9/21 between 0 and 23 @1").'
+        ' If None, the simulation will be annual.', default='None'
+    )
+
+    north = Inputs.int(
+        description='A number from -360 to 360 for the counterclockwise difference '
+        'between North and the positive Y-axis in degrees. 90 is west; 270 is east',
+        default=0, spec={'type': 'integer', 'maximum': 360, 'minimum': -360}
+    )
+
     filter_des_days = Inputs.str(
         description='A switch for whether the ddy-file should be filtered to only '
         'include 99.6 and 0.4 design days', default='filter-des-days',
@@ -20,6 +32,7 @@ class SimParDefault(Function):
     @command
     def create_sim_param(self):
         return 'honeybee-energy settings default-sim-par input.ddy ' \
+            '--run-period {{self.run_period}} --north {{self.north}} ' \
             '--{{self.filter_des_days}} --output-file sim_par.json'
 
     sim_par_json = Outputs.file(
@@ -41,7 +54,8 @@ class SimParLoadBalance(SimParDefault):
     @command
     def create_sim_param(self):
         return 'honeybee-energy settings load-balance-sim-par input.ddy --load-type ' \
-            '{{self.load_type}} --{{self.filter_des_days}} --output-file sim_par.json'
+            '{{self.load_type}} --run-period {{self.run_period}} --north ' \
+            '{{self.north}} --{{self.filter_des_days}} --output-file sim_par.json'
 
 
 @dataclass
@@ -51,6 +65,7 @@ class SimParComfort(SimParDefault):
     @command
     def create_sim_param(self):
         return 'honeybee-energy settings comfort-sim-par input.ddy ' \
+            '--run-period {{self.run_period}} --north {{self.north}} ' \
             '--{{self.filter_des_days}} --output-file sim_par.json'
 
 
@@ -64,6 +79,18 @@ class BaselineOrientationSimPars(Function):
         'SimulationParameter', path='input.ddy', extensions=['ddy']
     )
 
+    run_period = Inputs.str(
+        description='An AnalysisPeriod string or an IDF RunPeriod string to set the '
+        'start and end dates of the simulation (eg. "6/21 to 9/21 between 0 and 23 @1").'
+        ' If None, the simulation will be annual.', default='None'
+    )
+
+    north = Inputs.int(
+        description='A number from -360 to 360 for the counterclockwise difference '
+        'between North and the positive Y-axis in degrees. 90 is west; 270 is east',
+        default=0, spec={'type': 'integer', 'maximum': 360, 'minimum': -360}
+    )
+
     filter_des_days = Inputs.str(
         description='A switch for whether the ddy-file should be filtered to only '
         'include 99.6 and 0.4 design days', default='filter-des-days',
@@ -73,7 +100,8 @@ class BaselineOrientationSimPars(Function):
     @command
     def baseline_orientation_sim_pars(self):
         return 'honeybee-energy settings orientation-sim-pars input.ddy ' \
-            '0 90 180 270 --{{self.filter_des_days}} --folder output ' \
+            '0 90 180 270 --run-period {{self.run_period}} --start-north ' \
+            '{{self.north}} --{{self.filter_des_days}} --folder output ' \
             '--log-file output/sim_par_info.json'
 
     sim_par_list = Outputs.dict(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pollination-dsl==0.9.4
-honeybee-energy==1.66.16
+pollination-dsl==0.10.0
+honeybee-energy==1.67.8


### PR DESCRIPTION
I realized that the north input is critical for anyone working on a real project in an office (I don't think I have ever worked on a project were project north was the same as true north). Also, now that I realized the can just treat the run period as an analysis period string, this will be useful to expose on certain recipes.