### PR TITLE
ci(deps): Enable automerging for production deps

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -12,3 +12,7 @@ update_configs:
           dependency_name: "wheel"
       - match:
           dependency_name: "setuptools"
+    automerged_updates:
+      - match:
+          dependency_type: "all"
+          update_type: "all"


### PR DESCRIPTION
This is going to save me a huge amount of time and is desirable as long as the merge doesn't result in a new release.

We should remove this if we ever decide that we want to use "fix" tags for updates to requirements. But I think we'll reserve releases just for the cases where we add new features.