### PR TITLE
fix(simulate): Make sql and html required

### DIFF
--- a/pollination/honeybee_energy/simulate.py
+++ b/pollination/honeybee_energy/simulate.py
@@ -85,7 +85,7 @@ class SimulateModel(Function):
 
     sql = Outputs.file(
         description='The result SQL file output by the simulation.',
-        path='output/run/eplusout.sql', optional=True
+        path='output/run/eplusout.sql'
     )
 
     zsz = Outputs.file(
@@ -95,7 +95,7 @@ class SimulateModel(Function):
 
     html = Outputs.file(
         description='The result HTML page with summary reports output by the '
-        'simulation.', path='output/run/eplustbl.htm', optional=True
+        'simulation.', path='output/run/eplustbl.htm'
     )
 
     err = Outputs.file(


### PR DESCRIPTION
Technically, they can be bypassed if the user inputs a specific type of IDF but people keep getting failing simulations that look like they succeed so I am making them required again.