### PR TITLE
fix(simulate): Coordinate function with honeybee-energy changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The following packages and engines are included with this plugin:
 
 - `honeybee-energy` Python package. [PyPI](https://pypi.org/project/honeybee-energy/), [source](https://github.com/ladybug-tools/honeybee-energy).
 - `honeybee-energy-standards` Python package. [PyPI](https://pypi.org/project/honeybee-energy-standards/), [source](https://github.com/ladybug-tools/honeybee-energy-standards).
-- `honeybee-openstudio-gem` Ruby gem. [Rubygems](https://rubygems.org/gems/honeybee-openstudio), [source](https://github.com/ladybug-tools/honeybee-openstudio-gem).
+- `honeybee-openstudio` Python package. [PyPI](https://pypi.org/project/honeybee-openstudio), [source](https://github.com/ladybug-tools/honeybee-openstudio).
 - `Ironbug` Ironbug, including OpenStudio .NET bindings. [source](https://github.com/MingboPeng/Ironbug).
 - `OpenStudio`, including OpenStudio CLI. [source](https://github.com/NREL/OpenStudio/releases)
 - `EnergyPlus`. [source](https://github.com/NREL/EnergyPlus/releases).

--- a/pollination/honeybee_energy/simulate.py
+++ b/pollination/honeybee_energy/simulate.py
@@ -186,7 +186,7 @@ class SimulateModelRoomBypass(Function):
         return 'honeybee-energy simulate model model.hbjson weather.epw ' \
             '--sim-par-json sim-par.json --measures measures --additional-string ' \
             '"{{self.additional_string}}" --additional-idf additional.idf ' \
-            '--check-model --skip-no-rooms --folder output'
+            '--skip-no-rooms --folder output'
 
     hbjson = Outputs.file(
         description='A clean version of the input model that is in a format, which can '


### PR DESCRIPTION
The --check-model option was removed here:
https://github.com/ladybug-tools/honeybee-energy/commit/96fa6c8a8aadcd923053f7ab73ced22de4d441fb

... given that it is no longer possible to turn it off when using the Python translators to OpenStudio.